### PR TITLE
Add disabled property to Styleable base class and apply disabled styles

### DIFF
--- a/projects/ngx-monkey-ui/src/lib/bases/styleable.base.ts
+++ b/projects/ngx-monkey-ui/src/lib/bases/styleable.base.ts
@@ -81,6 +81,16 @@ export class Styleable implements OnInit, OnChanges {
 	@Input() sticky?: string = 'false';
 
 	/**
+	 * Whether the component should be disabled.
+	 */
+	@Input() disabled?: string = 'false';
+
+	/**
+	 * Indicates whether the component is disabled.
+	 */
+	isDisabledComponent: boolean = false;
+
+	/**
 	 * The current screen data.
 	 */
 	currentScreen!: MonkeyScreen;
@@ -150,6 +160,11 @@ export class Styleable implements OnInit, OnChanges {
 
 		if (this.check(this.sticky)) {
 			this.classList.push('position-sticky');
+		}
+
+		if (this.check(this.disabled)) {
+			this.classList.push('disabled');
+			this.isDisabledComponent = true;
 		}
 	}
 

--- a/projects/ngx-monkey-ui/src/lib/styles/components/_common.default.style.scss
+++ b/projects/ngx-monkey-ui/src/lib/styles/components/_common.default.style.scss
@@ -1,2 +1,9 @@
 @import '../components.themes';
 @import '../components.styles';
+
+.disabled,
+.disabled * {
+  cursor: not-allowed;
+  pointer-events: none;
+  opacity: 0.75;
+}


### PR DESCRIPTION
This pull request adds a new `disabled` property to the `Styleable` base class. When the `disabled` property is marked, the component will be visually disabled and user interactions will be blocked. The `disabled` property is applied to the component's styles by adding the `disabled` class and setting the `cursor` to `not-allowed`, `pointer-events` to `none`, and `opacity` to `0.75`. This allows developers to easily disable components when needed.