### PR TITLE
Add monkey-content-header component and tests

### DIFF
--- a/projects/ngx-monkey-ui-tests/src/app/app.component.html
+++ b/projects/ngx-monkey-ui-tests/src/app/app.component.html
@@ -37,6 +37,72 @@
     showHint
 ></monkey-aside-menu>
 
+<!-- DEMOS -->
+<monkey-card>
+    <monkey-content-header
+        [style]="currentStyle"
+        image="https://th.bing.com/th/id/OIP.6bDf-HbrDJFPfyRPJTYVZgHaG7?rs=1&pid=ImgDetMain"
+        header="Monkey UI"
+        subHeader="An Angular components lybrary"
+        [action]="contentHeaderAction"
+        
+    ></monkey-content-header>
+</monkey-card>
+
+<!-- STYLE CHANGE -->
+<monkey-card>
+    <monkey-icon-button
+        glow
+        alt="Monkey icon ejemplo apertura hacia la derecha"
+        [style]="currentStyle"
+        icon="arrow_right"
+        (onClick)="onClicked('default')"
+    ></monkey-icon-button>
+
+    <monkey-button
+        [style]="primaryStyle"
+        (onClick)="changeStyle(primaryStyle)"
+    >PRIMARY</monkey-button>
+
+    <monkey-button
+        [style]="secondaryStyle"
+        (onClick)="changeStyle(secondaryStyle)"
+    >SECONDARY</monkey-button>
+
+    <monkey-button
+        [style]="tertiaryStyle"
+        (onClick)="changeStyle(tertiaryStyle)"
+    >TERTIARY</monkey-button>
+
+    <monkey-button
+        [style]="warningStyle"
+        (onClick)="changeStyle(warningStyle)"
+    >WARNING</monkey-button>
+
+    <monkey-button
+        [style]="dangerStyle"
+        (onClick)="changeStyle(dangerStyle)"
+    >DANGER</monkey-button>
+
+    <monkey-button
+        [style]="successStyle"
+        (onClick)="changeStyle(successStyle)"
+    >SUCCESS</monkey-button>
+
+    <monkey-button
+        [style]="infoStyle"
+        (onClick)="changeStyle(infoStyle)"
+    >INFO</monkey-button>
+    
+    <monkey-icon-button
+        glow
+        alt="Monkey icon ejemplo apertura hacia la izquierda"
+        [style]="currentStyle"
+        icon="arrow_left"
+        (onClick)="onClicked('default')"
+    ></monkey-icon-button>
+</monkey-card>
+
 <!-- STYLES DEMOS -->
 <monkey-card>
     <monkey-buttons-group
@@ -317,60 +383,6 @@
         alt="Monkey icon button con estilo glow"
         [style]="currentStyle"
         icon="add"
-        (onClick)="onClicked('default')"
-    ></monkey-icon-button>
-</monkey-card>
-
-<!-- STYLE CHANGE -->
-<monkey-card>
-    <monkey-icon-button
-        glow
-        alt="Monkey icon ejemplo apertura hacia la derecha"
-        [style]="currentStyle"
-        icon="arrow_right"
-        (onClick)="onClicked('default')"
-    ></monkey-icon-button>
-
-    <monkey-button
-        [style]="primaryStyle"
-        (onClick)="changeStyle(primaryStyle)"
-    >PRIMARY</monkey-button>
-
-    <monkey-button
-        [style]="secondaryStyle"
-        (onClick)="changeStyle(secondaryStyle)"
-    >SECONDARY</monkey-button>
-
-    <monkey-button
-        [style]="tertiaryStyle"
-        (onClick)="changeStyle(tertiaryStyle)"
-    >TERTIARY</monkey-button>
-
-    <monkey-button
-        [style]="warningStyle"
-        (onClick)="changeStyle(warningStyle)"
-    >WARNING</monkey-button>
-
-    <monkey-button
-        [style]="dangerStyle"
-        (onClick)="changeStyle(dangerStyle)"
-    >DANGER</monkey-button>
-
-    <monkey-button
-        [style]="successStyle"
-        (onClick)="changeStyle(successStyle)"
-    >SUCCESS</monkey-button>
-
-    <monkey-button
-        [style]="infoStyle"
-        (onClick)="changeStyle(infoStyle)"
-    >INFO</monkey-button>
-    
-    <monkey-icon-button
-        glow
-        alt="Monkey icon ejemplo apertura hacia la izquierda"
-        [style]="currentStyle"
-        icon="arrow_left"
         (onClick)="onClicked('default')"
     ></monkey-icon-button>
 </monkey-card>

--- a/projects/ngx-monkey-ui-tests/src/app/app.component.ts
+++ b/projects/ngx-monkey-ui-tests/src/app/app.component.ts
@@ -52,6 +52,8 @@ export class AppComponent {
     { label: 'Aside 5', icon: 'navigate_next', route: '/aside5' },
   ];
 
+  contentHeaderAction: MonkeyButtonData = new MonkeyButtonData(this.primaryStyle, 'Show alert', () => this.onClicked('Content header'), 'info', 'right');
+
   buttonsGroupData: MonkeyButtonData[] = [
     new MonkeyButtonData(this.primaryStyle, 'First', () => this.onClicked('First'), 'info', 'left'),
     new MonkeyButtonData(this.secondaryStyle, 'Second', () => this.onClicked('Second')),

--- a/projects/ngx-monkey-ui/src/lib/components/third-level/content-header/content-header.component.html
+++ b/projects/ngx-monkey-ui/src/lib/components/third-level/content-header/content-header.component.html
@@ -1,0 +1,1 @@
+<p>content-header works!</p>

--- a/projects/ngx-monkey-ui/src/lib/components/third-level/content-header/content-header.component.html
+++ b/projects/ngx-monkey-ui/src/lib/components/third-level/content-header/content-header.component.html
@@ -4,6 +4,7 @@
   [alt]="header"
   [width]="imageSize"
   [height]="imageSize"
+  (onClickImage)="action?.action()"
   fullRounded
   
   [brutalist]="brutalist"

--- a/projects/ngx-monkey-ui/src/lib/components/third-level/content-header/content-header.component.html
+++ b/projects/ngx-monkey-ui/src/lib/components/third-level/content-header/content-header.component.html
@@ -1,1 +1,57 @@
-<p>content-header works!</p>
+<monkey-image
+  [style]="style"
+  [src]="image"
+  [alt]="header"
+  [width]="imageSize"
+  [height]="imageSize"
+  fullRounded
+  
+  [brutalist]="brutalist"
+  [glass]="glass"
+  [flat]="flat"
+  [ghost]="ghost"
+  [glow]="glow"
+></monkey-image>
+
+<div
+  class="texts"
+>
+  <span
+    class="content-header-header"
+    [class.dark-theme]="isDarkMode$ | async"
+  >
+    {{ header }}
+  </span>
+  
+  <span
+    *ngIf="subHeader"
+    class="content-header-subheader"
+    [class.dark-theme]="isDarkMode$ | async"
+  >
+    {{ subHeader }}
+  </span>
+</div>
+
+<monkey-button
+  *ngIf="action"
+  [style]="style"
+  (onClick)="action.action()"
+  
+  [brutalist]="brutalist"
+  [glass]="glass"
+  [flat]="flat"
+  [ghost]="ghost"
+  [glow]="glow"
+>
+  <span
+    *ngIf="action.icon && action.iconPosition === 'left'"
+    class="material-symbols-outlined"
+  >{{ action.icon }}</span>
+
+  {{ action.text }}
+
+  <span
+    *ngIf="action.icon && action.iconPosition === 'right'"
+    class="material-symbols-outlined"
+  >{{ action.icon }}</span>
+</monkey-button>

--- a/projects/ngx-monkey-ui/src/lib/components/third-level/content-header/content-header.component.scss
+++ b/projects/ngx-monkey-ui/src/lib/components/third-level/content-header/content-header.component.scss
@@ -1,0 +1,2 @@
+:host ::ng-deep {
+}

--- a/projects/ngx-monkey-ui/src/lib/components/third-level/content-header/content-header.component.scss
+++ b/projects/ngx-monkey-ui/src/lib/components/third-level/content-header/content-header.component.scss
@@ -1,2 +1,24 @@
 :host ::ng-deep {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 15px;
+
+  .texts {
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+
+    .content-header-header {
+      font-size: 1.8rem;
+      font-weight: 600;
+      color: var(--background-color-contrast-hight);
+    }
+
+    .content-header-subheader {
+      font-size: 1.2rem;
+      font-weight: 400;
+      color: var(--background-color-contrast-low);
+    }
+  }
 }

--- a/projects/ngx-monkey-ui/src/lib/components/third-level/content-header/content-header.component.spec.ts
+++ b/projects/ngx-monkey-ui/src/lib/components/third-level/content-header/content-header.component.spec.ts
@@ -1,0 +1,21 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { MonkeyContentHeader } from './content-header.component';
+
+describe('ContentHeaderComponent', () => {
+  let component: MonkeyContentHeader;
+  let fixture: ComponentFixture<MonkeyContentHeader>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [MonkeyContentHeader]
+    });
+    fixture = TestBed.createComponent(MonkeyContentHeader);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/projects/ngx-monkey-ui/src/lib/components/third-level/content-header/content-header.component.ts
+++ b/projects/ngx-monkey-ui/src/lib/components/third-level/content-header/content-header.component.ts
@@ -1,5 +1,7 @@
-import { Component } from '@angular/core';
+import { Component, Input, OnChanges, OnInit } from '@angular/core';
 import { Styleable } from '../../../bases/styleable.base';
+import { MonkeyButtonData } from '../../../objects/classes/button-data.class';
+import { ThemeService } from '../../../services/theme.service';
 
 @Component({
   selector: 'monkey-content-header',
@@ -9,6 +11,93 @@ import { Styleable } from '../../../bases/styleable.base';
     './content-header.component.scss',
   ]
 })
-export class MonkeyContentHeader extends Styleable {
+export class MonkeyContentHeader extends Styleable implements OnInit, OnChanges {
+
+  @Input() image!: string;
+
+  @Input() header!: string;
+
+  @Input() subHeader!: string;
+
+  @Input() action?: MonkeyButtonData;
+
+  // COMPONENTS SIZES
+  
+  /**
+   * The size of the content header on extra small screens.
+   */
+  @Input() xs?: string = 'xs';
+
+  /**
+   * The size of the avatar for small screens.
+   */
+  @Input() sm?: string = 'sm';
+
+  /**
+   * The size of the avatar for medium screens.
+   */
+  @Input() md?: string = 'md';
+
+  /**
+   * The size of the avatar for large screens.
+   */
+  @Input() lg?: string = 'lg';
+
+  /**
+   * The size of the avatar for extra large screens.
+   */
+  @Input() xl?: string = 'xl';
+
+  /**
+   * Observable that emits a boolean indicating whether the theme is in dark mode or not.
+   */
+  isDarkMode$ = this.themeService.isDarkMode$;
+
+  imageSize: number = 20;
+
+  /**
+   * Creates an instance of MonkeyContentHeader.
+   * @param themeService The theme service.
+   */
+  constructor(
+    private themeService: ThemeService,
+  ) {
+    super();
+  }
+
+  override ngOnInit(): void {
+    super.ngOnInit();
+    this.imageSize = this.getSize();
+  }
+
+  override ngOnChanges(): void {
+    super.ngOnChanges();
+    this.imageSize = this.getSize();
+  }
+
+  /**
+   * Returns the size based on the provided breakpoints.
+   * If none of the breakpoints are set, it returns a default size of 30.
+   * @returns The size as a number.
+   */
+  private getSize(): number {
+    if (this.check(this.xs)) {
+      return 60;
+    }
+
+    if (this.check(this.sm)) {
+      return 80;
+    }
+
+    if (this.check(this.lg)) {
+      return 120;
+    }
+
+    if (this.check(this.xl)) {
+      return 140;
+    }
+
+    return 100;
+  }
 
 }

--- a/projects/ngx-monkey-ui/src/lib/components/third-level/content-header/content-header.component.ts
+++ b/projects/ngx-monkey-ui/src/lib/components/third-level/content-header/content-header.component.ts
@@ -1,0 +1,14 @@
+import { Component } from '@angular/core';
+import { Styleable } from '../../../bases/styleable.base';
+
+@Component({
+  selector: 'monkey-content-header',
+  templateUrl: './content-header.component.html',
+  styleUrls: [
+    '../../../styles/components/_common.default.style.scss',
+    './content-header.component.scss',
+  ]
+})
+export class MonkeyContentHeader extends Styleable {
+
+}

--- a/projects/ngx-monkey-ui/src/lib/ngx-monkey-ui.module.ts
+++ b/projects/ngx-monkey-ui/src/lib/ngx-monkey-ui.module.ts
@@ -28,6 +28,7 @@ import { MonkeyAlert } from './components/third-level/alert/alert.component';
 import { MonkeyTooltip } from './components/third-level/tooltip/tooltip.component';
 import { MonkeyMenu } from './components/third-level/menu/menu.component';
 import { MonkeyAsideMenu } from './components/third-level/aside-menu/aside-menu.component';
+import { MonkeyContentHeader } from './components/third-level/content-header/content-header.component';
 
 // THIRD LEVEL
 
@@ -57,6 +58,7 @@ import { MonkeyThemeChanger } from './components/fourth-level/theme-changer/them
     MonkeyDropdown,
     MonkeyButtonsGroup,
     MonkeyAsideMenu,
+    MonkeyContentHeader,
   ],
   imports: [
     CommonModule,
@@ -79,6 +81,7 @@ import { MonkeyThemeChanger } from './components/fourth-level/theme-changer/them
     MonkeyDropdown,
     MonkeyButtonsGroup,
     MonkeyAsideMenu,
+    MonkeyContentHeader,
   ],
 })
 export class NgxMonkeyUiModule { }

--- a/projects/ngx-monkey-ui/src/public-api.ts
+++ b/projects/ngx-monkey-ui/src/public-api.ts
@@ -83,8 +83,11 @@ export * from './lib/ngx-monkey-ui.module';
     // Tooltip
     export * from './lib/components/third-level/tooltip/tooltip.component';
 
-    // Tooltip
+    // Aside menu
     export * from './lib/components/third-level/aside-menu/aside-menu.component';
+
+    // Content header
+    export * from './lib/components/third-level/content-header/content-header.component';
 
   // THIRD LEVEL
 


### PR DESCRIPTION
This pull request adds the monkey-content-header component and its corresponding tests. The component is responsible for displaying a header with an optional image, header text, subheader text, and an optional action button.