### PR TITLE
Fix aside menu behavior on extra large screens

### DIFF
--- a/projects/ngx-monkey-ui/src/lib/components/third-level/aside-menu/aside-menu.component.html
+++ b/projects/ngx-monkey-ui/src/lib/components/third-level/aside-menu/aside-menu.component.html
@@ -53,7 +53,7 @@
         [style]="style"
         discreet
       >
-        {{ isAsideOpened ? option.label : '' }}
+        {{ isAsideOpened || openedByLongScreen ? option.label : '' }}
 
         <monkey-icon
           [icon]="option.icon ? option.icon : DEFAULT_ICON"
@@ -71,7 +71,7 @@
         >
           <span
             class="option-group-label"
-            *ngIf="isAsideOpened"
+            *ngIf="isAsideOpened || openedByLongScreen"
           >{{ option.label }}</span>
           
           <monkey-icon
@@ -89,7 +89,7 @@
           [style]="style"
           discreet
         >
-          {{ isAsideOpened ? optionChildren.label : '' }}
+          {{ isAsideOpened || openedByLongScreen ? optionChildren.label : '' }}
 
           <monkey-icon
             [icon]="optionChildren.icon ? optionChildren.icon : DEFAULT_ICON"

--- a/projects/ngx-monkey-ui/src/lib/components/third-level/aside-menu/aside-menu.component.scss
+++ b/projects/ngx-monkey-ui/src/lib/components/third-level/aside-menu/aside-menu.component.scss
@@ -38,6 +38,10 @@
     }
   }
 
+  .aside-menu-content-list > section {
+    background-color: var(--background-color);
+  }
+
   .aside-menu-toggle + .aside-menu {
     .aside-menu-content-list {
       padding-top: 65px;

--- a/projects/ngx-monkey-ui/src/lib/components/third-level/aside-menu/aside-menu.component.ts
+++ b/projects/ngx-monkey-ui/src/lib/components/third-level/aside-menu/aside-menu.component.ts
@@ -96,6 +96,8 @@ export class MonkeyAsideMenu extends Styleable {
 
   backgroundStyle: MonkeyStyle = MonkeyStyle.BACKGROUND;
 
+  openedByLongScreen = false;
+
   /**
    * Observable that emits a boolean indicating whether the theme is in dark mode or not.
    */
@@ -114,7 +116,7 @@ export class MonkeyAsideMenu extends Styleable {
    */
   override ngOnInit() {
     super.ngOnInit();
-    
+
     if (this.data) {
       this.currentOption = !this.data[0].children ? this.data[0] : this.data[0].children![0];
     }
@@ -129,6 +131,14 @@ export class MonkeyAsideMenu extends Styleable {
     super.ngOnChanges();
 
     this.screenService.screenChanges$.subscribe((currentScreen: MonkeyScreen) => {
+      if (currentScreen.isScreenSizeUp(ScreenSize.XL)) {
+        this.openedByLongScreen = true;
+        this.openMenu();
+      } else {
+        this.openedByLongScreen = false;
+        this.closeMenu();
+      }
+
       if (!this.check(this.showHint)) {
         this.canShowHint = false;
         return;
@@ -172,6 +182,11 @@ export class MonkeyAsideMenu extends Styleable {
 
   private changeAsideWidth() {
     const asideContent = document.getElementById('aside-menu-content');
+    if (this.openedByLongScreen) {
+      asideContent!.style.width = this.OPENED_ASIDE_WIDTH;
+      return;
+    }
+
     if (!this.isAsideOpened) {
       if (this.check(this.showHint) && this.canShowHint) {
         asideContent!.style.width = this.CLOSED_ASIDE_HINT_WIDTH;
@@ -180,7 +195,7 @@ export class MonkeyAsideMenu extends Styleable {
       asideContent!.style.width = this.CLOSED_ASIDE_WIDTH;
       return;
     }
-    
+
     asideContent!.style.width = this.OPENED_ASIDE_WIDTH;
     return;
   }
@@ -201,8 +216,8 @@ export class MonkeyAsideMenu extends Styleable {
    */
   private navigateToPage(option: MenuOption) {
     this.optionSelected.emit(option);
-    
-    if(this.check(this.selfNavigation)) {
+
+    if (this.check(this.selfNavigation)) {
       this.router.navigate([option.route]);
     }
   }


### PR DESCRIPTION
This pull request fixes the behavior of the aside menu on extra large screens. Previously, the aside menu would expand when the screen was extra large, causing a gap in the background. This PR ensures that the aside menu only expands when necessary and fixes the background gap issue.